### PR TITLE
Remove canilunzt translators from vulpkanin spawn

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -22,7 +22,6 @@
     requiredLegs: 2
   - type: VulpLanguageSpeaker
   - type: VulpLangaugeListener
-  - type: VulpGiveTranslator
   - type: SizeAttributeWhitelist
     short: true
     shortscale: 0.8


### PR DESCRIPTION


## About the PR
removed vulps spawning with the translator

## Why / Balance
Because as far as I am aware there is no canilunzt language, meaning their only purpose is to give vulpkanin players 183 spesos for free every time they spawn in


**Changelog**

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- remove: Canilunzt translator from vulpkanin


