### PR TITLE
replace beta oreo with FTL beacon

### DIFF
--- a/Resources/Maps/_NF/Outpost/oreo.yml
+++ b/Resources/Maps/_NF/Outpost/oreo.yml
@@ -43,8 +43,7 @@ entities:
     components:
     - name: Pax Oreo Border Station
       type: MetaData
-    - pos: -73.25791,-31.06069
-      parent: 1
+    - parent: 1
       type: Transform
     - chunks:
         3,1:

--- a/Resources/Maps/_PAX/Outpost/ftlbeacon.yml
+++ b/Resources/Maps/_PAX/Outpost/ftlbeacon.yml
@@ -1,0 +1,720 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  33: FloorDarkMono
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - name: map 120
+      type: MetaData
+    - type: Transform
+    - type: Map
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
+    - type: LoadedMap
+  - uid: 3
+    components:
+    - name: FTL Beacon
+      type: MetaData
+    - parent: 1
+      type: Transform
+    - chunks:
+        0,0:
+          ind: 0,0
+          tiles: IQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+      type: MapGrid
+    - type: Broadphase
+    - bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+      type: Gravity
+    - chunkCollection:
+        version: 2
+        nodes: []
+      type: DecalGrid
+    - version: 2
+      data:
+        tiles:
+          0,0:
+            0: 64511
+            1: 1024
+          -1,0:
+            0: 57343
+            1: 8192
+          -1,-1:
+            0: 65535
+          0,-1:
+            0: 65535
+          0,1:
+            0: 127
+          1,0:
+            0: 4915
+          1,1:
+            0: 1
+          -2,0:
+            0: 2184
+          -1,1:
+            0: 207
+          -2,-1:
+            0: 34816
+          -1,-2:
+            0: 49152
+          0,-2:
+            0: 28672
+          1,-1:
+            0: 13073
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+      type: GridAtmosphere
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - id: FTLBeacon
+      type: BecomesStation
+    - type: StationTransit
+    - type: IFF
+    - type: FTLDestination
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 4
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 3
+      type: Transform
+  - uid: 35
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 36
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 37
+    components:
+    - pos: 1.5,-4.5
+      parent: 3
+      type: Transform
+  - uid: 38
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 3
+      type: Transform
+  - uid: 39
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 3
+      type: Transform
+  - uid: 40
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,5.5
+      parent: 3
+      type: Transform
+  - uid: 41
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 42
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 43
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 3
+      type: Transform
+  - uid: 44
+    components:
+    - pos: 0.5,-4.5
+      parent: 3
+      type: Transform
+  - uid: 45
+    components:
+    - pos: -0.5,-4.5
+      parent: 3
+      type: Transform
+- proto: APCBasic
+  entities:
+  - uid: 14
+    components:
+    - pos: 0.5,1.5
+      parent: 3
+      type: Transform
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 94
+    components:
+    - pos: 5.5,-0.5
+      parent: 3
+      type: Transform
+  - uid: 95
+    components:
+    - pos: 5.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 96
+    components:
+    - pos: 5.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 97
+    components:
+    - pos: 1.5,5.5
+      parent: 3
+      type: Transform
+  - uid: 98
+    components:
+    - pos: 0.5,5.5
+      parent: 3
+      type: Transform
+  - uid: 99
+    components:
+    - pos: -0.5,5.5
+      parent: 3
+      type: Transform
+  - uid: 100
+    components:
+    - pos: -4.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 101
+    components:
+    - pos: -4.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 102
+    components:
+    - pos: -4.5,-0.5
+      parent: 3
+      type: Transform
+  - uid: 103
+    components:
+    - pos: -0.5,-4.5
+      parent: 3
+      type: Transform
+  - uid: 104
+    components:
+    - pos: 0.5,-4.5
+      parent: 3
+      type: Transform
+  - uid: 105
+    components:
+    - pos: 1.5,-4.5
+      parent: 3
+      type: Transform
+- proto: CableApcExtension
+  entities:
+  - uid: 21
+    components:
+    - pos: 0.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 22
+    components:
+    - pos: 0.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 23
+    components:
+    - pos: 0.5,-0.5
+      parent: 3
+      type: Transform
+  - uid: 24
+    components:
+    - pos: 0.5,-1.5
+      parent: 3
+      type: Transform
+  - uid: 25
+    components:
+    - pos: 1.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 26
+    components:
+    - pos: 2.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 27
+    components:
+    - pos: -0.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 28
+    components:
+    - pos: -1.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 29
+    components:
+    - pos: 0.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 30
+    components:
+    - pos: 0.5,2.5
+      parent: 3
+      type: Transform
+  - uid: 65
+    components:
+    - pos: -2.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 66
+    components:
+    - pos: 3.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 67
+    components:
+    - pos: 0.5,-2.5
+      parent: 3
+      type: Transform
+  - uid: 68
+    components:
+    - pos: 0.5,3.5
+      parent: 3
+      type: Transform
+- proto: CableHV
+  entities:
+  - uid: 16
+    components:
+    - pos: 0.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 17
+    components:
+    - pos: -0.5,0.5
+      parent: 3
+      type: Transform
+- proto: CableMV
+  entities:
+  - uid: 18
+    components:
+    - pos: -0.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 19
+    components:
+    - pos: -0.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 20
+    components:
+    - pos: 0.5,1.5
+      parent: 3
+      type: Transform
+- proto: ComputerRadar
+  entities:
+  - uid: 70
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 72
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 3
+      type: Transform
+- proto: ComputerShipyard
+  entities:
+  - uid: 69
+    components:
+    - pos: 0.5,-1.5
+      parent: 3
+      type: Transform
+    - containers:
+        ShipyardConsole-targetId: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+      type: ContainerContainer
+  - uid: 71
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 3
+      type: Transform
+    - containers:
+        ShipyardConsole-targetId: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+      type: ContainerContainer
+- proto: GeneratorRTG
+  entities:
+  - uid: 5
+    components:
+    - pos: 0.5,0.5
+      parent: 3
+      type: Transform
+- proto: Grille
+  entities:
+  - uid: 85
+    components:
+    - pos: 3.5,-3.5
+      parent: 3
+      type: Transform
+  - uid: 86
+    components:
+    - pos: 4.5,-2.5
+      parent: 3
+      type: Transform
+  - uid: 87
+    components:
+    - pos: 4.5,3.5
+      parent: 3
+      type: Transform
+  - uid: 88
+    components:
+    - pos: 3.5,4.5
+      parent: 3
+      type: Transform
+  - uid: 89
+    components:
+    - pos: -2.5,4.5
+      parent: 3
+      type: Transform
+  - uid: 90
+    components:
+    - pos: -3.5,3.5
+      parent: 3
+      type: Transform
+  - uid: 91
+    components:
+    - pos: -3.5,-2.5
+      parent: 3
+      type: Transform
+  - uid: 92
+    components:
+    - pos: -2.5,-3.5
+      parent: 3
+      type: Transform
+- proto: MachineCryoSleepPod
+  entities:
+  - uid: 6
+    components:
+    - pos: -2.5,3.5
+      parent: 3
+      type: Transform
+  - uid: 82
+    components:
+    - pos: -2.5,-2.5
+      parent: 3
+      type: Transform
+  - uid: 83
+    components:
+    - pos: 3.5,-2.5
+      parent: 3
+      type: Transform
+  - uid: 84
+    components:
+    - pos: 3.5,3.5
+      parent: 3
+      type: Transform
+- proto: PlastitaniumWindowIndestructible
+  entities:
+  - uid: 48
+    components:
+    - pos: -2.5,4.5
+      parent: 3
+      type: Transform
+  - uid: 62
+    components:
+    - pos: -3.5,3.5
+      parent: 3
+      type: Transform
+  - uid: 73
+    components:
+    - pos: -3.5,-2.5
+      parent: 3
+      type: Transform
+  - uid: 75
+    components:
+    - pos: -2.5,-3.5
+      parent: 3
+      type: Transform
+  - uid: 76
+    components:
+    - pos: 4.5,-2.5
+      parent: 3
+      type: Transform
+  - uid: 78
+    components:
+    - pos: 3.5,-3.5
+      parent: 3
+      type: Transform
+  - uid: 79
+    components:
+    - pos: 4.5,3.5
+      parent: 3
+      type: Transform
+  - uid: 81
+    components:
+    - pos: 3.5,4.5
+      parent: 3
+      type: Transform
+- proto: Poweredlight
+  entities:
+  - uid: 31
+    components:
+    - pos: 0.5,-1.5
+      parent: 3
+      type: Transform
+  - uid: 32
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 33
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 3
+      type: Transform
+  - uid: 34
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 3
+      type: Transform
+- proto: SubstationWallBasic
+  entities:
+  - uid: 15
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 3
+      type: Transform
+- proto: WallPlastitaniumIndestructible
+  entities:
+  - uid: 2
+    components:
+    - pos: -0.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 7
+    components:
+    - pos: 0.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 8
+    components:
+    - pos: 1.5,1.5
+      parent: 3
+      type: Transform
+  - uid: 9
+    components:
+    - pos: 1.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 10
+    components:
+    - pos: 1.5,-0.5
+      parent: 3
+      type: Transform
+  - uid: 11
+    components:
+    - pos: 0.5,-0.5
+      parent: 3
+      type: Transform
+  - uid: 12
+    components:
+    - pos: -0.5,-0.5
+      parent: 3
+      type: Transform
+  - uid: 13
+    components:
+    - pos: -0.5,0.5
+      parent: 3
+      type: Transform
+  - uid: 46
+    components:
+    - pos: -1.5,-4.5
+      parent: 3
+      type: Transform
+  - uid: 47
+    components:
+    - pos: -1.5,-3.5
+      parent: 3
+      type: Transform
+  - uid: 49
+    components:
+    - pos: -3.5,-1.5
+      parent: 3
+      type: Transform
+  - uid: 50
+    components:
+    - pos: -4.5,-1.5
+      parent: 3
+      type: Transform
+  - uid: 51
+    components:
+    - pos: -4.5,2.5
+      parent: 3
+      type: Transform
+  - uid: 52
+    components:
+    - pos: -3.5,2.5
+      parent: 3
+      type: Transform
+  - uid: 53
+    components:
+    - pos: -1.5,4.5
+      parent: 3
+      type: Transform
+  - uid: 54
+    components:
+    - pos: -1.5,5.5
+      parent: 3
+      type: Transform
+  - uid: 55
+    components:
+    - pos: 2.5,5.5
+      parent: 3
+      type: Transform
+  - uid: 56
+    components:
+    - pos: 2.5,4.5
+      parent: 3
+      type: Transform
+  - uid: 57
+    components:
+    - pos: -3.5,4.5
+      parent: 3
+      type: Transform
+  - uid: 58
+    components:
+    - pos: 4.5,2.5
+      parent: 3
+      type: Transform
+  - uid: 59
+    components:
+    - pos: 5.5,2.5
+      parent: 3
+      type: Transform
+  - uid: 60
+    components:
+    - pos: 5.5,-1.5
+      parent: 3
+      type: Transform
+  - uid: 61
+    components:
+    - pos: 4.5,-1.5
+      parent: 3
+      type: Transform
+  - uid: 63
+    components:
+    - pos: 2.5,-3.5
+      parent: 3
+      type: Transform
+  - uid: 64
+    components:
+    - pos: 2.5,-4.5
+      parent: 3
+      type: Transform
+  - uid: 74
+    components:
+    - pos: 4.5,4.5
+      parent: 3
+      type: Transform
+  - uid: 77
+    components:
+    - pos: 4.5,-3.5
+      parent: 3
+      type: Transform
+  - uid: 80
+    components:
+    - pos: -3.5,-3.5
+      parent: 3
+      type: Transform
+- proto: WarpPoint
+  entities:
+  - uid: 93
+    components:
+    - pos: 0.5,0.5
+      parent: 3
+      type: Transform
+...

--- a/Resources/Prototypes/_NF/Maps/Outpost/ftlbeacon.yml
+++ b/Resources/Prototypes/_NF/Maps/Outpost/ftlbeacon.yml
@@ -1,0 +1,13 @@
+- type: gameMap
+  id: FTLBeacon
+  mapName: 'FTL Beacon'
+  mapPath: /Maps/_PAX/Outpost/ftlbeacon.yml
+  minPlayers: 0
+  maxPlayers: 100
+  stations:
+    FTLBeacon:
+      stationProto: StandardFrontierStation
+      components:
+      - type: StationNameSetup
+        mapNameTemplate: 'FTL Beacon'
+

--- a/Resources/Prototypes/_PAX/Sectors/beta.yml
+++ b/Resources/Prototypes/_PAX/Sectors/beta.yml
@@ -10,8 +10,8 @@
       r: 1
       g: 2
       b: 3
-    stationId: Oreo
-    stationName: Pax Oreo Border Station
+    stationId: FTLBeacon
+    stationName: FTL Beacon
   outposts:
   - type: sectorOutpost
     id: 1


### PR DESCRIPTION

## About the PR
We want to replace BEta Oreo with an FTL beacon. THe Hegemony wouldn't place such an expensive station in a lawless sector.

**Changelog**


:cl:
- add: FTLBeacon!
- remove: Removed Oreo in beta sector!

