### PR TITLE
NC Shuriken - shock salvage operation vessel added. Dematerializer fire rate and reload made faster, starting cash to 30k

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -27,7 +27,7 @@ namespace Content.Shared.Preferences
         public const int MaxNameLength = 32;
         public const int MaxDescLength = 512;
 
-        public const int DefaultBalance = 25000;
+        public const int DefaultBalance = 30000;
 
         private readonly Dictionary<string, JobPriority> _jobPriorities;
         private readonly List<string> _antagPreferences;

--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -3350,3 +3350,13 @@ Entries:
     message: Bwoink sound fixed and made less scary.
   id: 4825
   time: '2024-07-22T21:03:54.0000000+00:00'
+- author: Gry
+  changes:
+  - type: Add
+    message: NC Shuriken - shock salvage operation vessel has been added to expedition shipyard.
+  - type: Tweak
+    message: Matter Dematerializer shuttle gun is now 50% times faster, and recharges in half the previous time.
+  - type: Tweak
+    message: Default money characters start with increased from 25k to 30k.
+  id: 4826
+  time: '2024-07-22T16:23:54.0000000+00:00'

--- a/Resources/Maps/_PAX/Shuttles/shuriken.yml
+++ b/Resources/Maps/_PAX/Shuttles/shuriken.yml
@@ -1,0 +1,2666 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  85: FloorSteel
+  113: Lattice
+  114: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 2
+    components:
+    - name: NC Shuriken
+      type: MetaData
+    - pos: -0.640625,-0.46875
+      parent: invalid
+      type: Transform
+    - chunks:
+        0,0:
+          ind: 0,0
+          tiles: VQAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAcgAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAVQAAAAAAVQAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: VQAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVQAAAAAAVQAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,1:
+          ind: -1,1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcgAAAAAAcgAAAAAAcgAAAAAA
+          version: 6
+      type: MapGrid
+    - type: Broadphase
+    - bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+      type: Gravity
+    - chunkCollection:
+        version: 2
+        nodes: []
+      type: DecalGrid
+    - version: 2
+      data:
+        tiles:
+          0,0:
+            0: 30719
+          -1,0:
+            0: 52462
+          0,1:
+            0: 30583
+          0,2:
+            0: 65535
+          0,3:
+            0: 65535
+          1,1:
+            0: 4096
+          1,2:
+            0: 65299
+          1,3:
+            0: 8191
+          2,2:
+            0: 65424
+          2,3:
+            0: 40959
+          3,2:
+            0: 13104
+          3,3:
+            0: 13107
+          -4,2:
+            0: 34944
+          -4,3:
+            0: 34952
+          -3,2:
+            0: 65328
+          -3,3:
+            0: 16383
+          -2,2:
+            0: 65304
+          -2,3:
+            0: 8191
+          -1,1:
+            0: 56524
+          -1,2:
+            0: 65535
+          -1,3:
+            0: 65535
+          0,4:
+            0: 30591
+          0,5:
+            0: 63359
+          0,6:
+            0: 255
+          1,4:
+            0: 19
+          -2,4:
+            0: 8
+          -1,4:
+            0: 52447
+          -1,5:
+            0: 60622
+          -1,6:
+            0: 238
+          0,-1:
+            0: 61440
+          -1,-1:
+            0: 57344
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+      type: GridAtmosphere
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirCanister
+  entities:
+  - uid: 403
+    components:
+    - pos: 1.5,19.5
+      parent: 2
+      type: Transform
+- proto: AirlockCaptainLocked
+  entities:
+  - uid: 152
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,10.5
+      parent: 2
+      type: Transform
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 69
+    components:
+    - pos: -0.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 70
+    components:
+    - pos: 1.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 115
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 11.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 116
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 11.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 117
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 118
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 119
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -10.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 120
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -10.5,11.5
+      parent: 2
+      type: Transform
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 59
+    components:
+    - pos: 1.5,-0.5
+      parent: 2
+      type: Transform
+  - uid: 60
+    components:
+    - pos: -0.5,-0.5
+      parent: 2
+      type: Transform
+  - uid: 102
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 13.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 109
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 13.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 111
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -12.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 112
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -12.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 113
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,25.5
+      parent: 2
+      type: Transform
+  - uid: 114
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,25.5
+      parent: 2
+      type: Transform
+- proto: APCBasic
+  entities:
+  - uid: 306
+    components:
+    - pos: 2.5,10.5
+      parent: 2
+      type: Transform
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 409
+    components:
+    - pos: 1.5,-0.5
+      parent: 2
+      type: Transform
+  - uid: 410
+    components:
+    - pos: -0.5,-0.5
+      parent: 2
+      type: Transform
+  - uid: 411
+    components:
+    - pos: 13.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 412
+    components:
+    - pos: 13.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 413
+    components:
+    - pos: 1.5,25.5
+      parent: 2
+      type: Transform
+  - uid: 414
+    components:
+    - pos: -0.5,25.5
+      parent: 2
+      type: Transform
+  - uid: 415
+    components:
+    - pos: -12.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 416
+    components:
+    - pos: -12.5,11.5
+      parent: 2
+      type: Transform
+- proto: Autolathe
+  entities:
+  - uid: 446
+    components:
+    - pos: 7.5,13.5
+      parent: 2
+      type: Transform
+- proto: BedsheetMedical
+  entities:
+  - uid: 187
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 2
+      type: Transform
+- proto: CableApcExtension
+  entities:
+  - uid: 110
+    components:
+    - pos: 9.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 314
+    components:
+    - pos: 2.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 315
+    components:
+    - pos: 2.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 316
+    components:
+    - pos: 1.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 317
+    components:
+    - pos: 0.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 318
+    components:
+    - pos: 0.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 319
+    components:
+    - pos: 0.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 320
+    components:
+    - pos: 0.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 321
+    components:
+    - pos: 0.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 322
+    components:
+    - pos: 0.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 323
+    components:
+    - pos: 0.5,7.5
+      parent: 2
+      type: Transform
+  - uid: 324
+    components:
+    - pos: 0.5,6.5
+      parent: 2
+      type: Transform
+  - uid: 325
+    components:
+    - pos: 0.5,5.5
+      parent: 2
+      type: Transform
+  - uid: 326
+    components:
+    - pos: 0.5,4.5
+      parent: 2
+      type: Transform
+  - uid: 327
+    components:
+    - pos: 0.5,3.5
+      parent: 2
+      type: Transform
+  - uid: 328
+    components:
+    - pos: -0.5,3.5
+      parent: 2
+      type: Transform
+  - uid: 329
+    components:
+    - pos: -0.5,2.5
+      parent: 2
+      type: Transform
+  - uid: 330
+    components:
+    - pos: -0.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 331
+    components:
+    - pos: -0.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 332
+    components:
+    - pos: 0.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 333
+    components:
+    - pos: 1.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 334
+    components:
+    - pos: 1.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 335
+    components:
+    - pos: 1.5,2.5
+      parent: 2
+      type: Transform
+  - uid: 336
+    components:
+    - pos: 1.5,3.5
+      parent: 2
+      type: Transform
+  - uid: 337
+    components:
+    - pos: 3.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 338
+    components:
+    - pos: 3.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 339
+    components:
+    - pos: 3.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 340
+    components:
+    - pos: 3.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 341
+    components:
+    - pos: 4.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 342
+    components:
+    - pos: 5.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 343
+    components:
+    - pos: 6.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 344
+    components:
+    - pos: 7.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 345
+    components:
+    - pos: 8.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 346
+    components:
+    - pos: 9.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 347
+    components:
+    - pos: 10.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 348
+    components:
+    - pos: 11.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 349
+    components:
+    - pos: 12.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 350
+    components:
+    - pos: 12.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 351
+    components:
+    - pos: 12.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 352
+    components:
+    - pos: 11.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 353
+    components:
+    - pos: 10.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 354
+    components:
+    - pos: 9.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 355
+    components:
+    - pos: -11.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 356
+    components:
+    - pos: 3.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 357
+    components:
+    - pos: 3.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 358
+    components:
+    - pos: 3.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 359
+    components:
+    - pos: 2.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 360
+    components:
+    - pos: 1.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 361
+    components:
+    - pos: 0.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 362
+    components:
+    - pos: 0.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 363
+    components:
+    - pos: 0.5,17.5
+      parent: 2
+      type: Transform
+  - uid: 364
+    components:
+    - pos: 0.5,18.5
+      parent: 2
+      type: Transform
+  - uid: 365
+    components:
+    - pos: 0.5,19.5
+      parent: 2
+      type: Transform
+  - uid: 366
+    components:
+    - pos: 0.5,20.5
+      parent: 2
+      type: Transform
+  - uid: 367
+    components:
+    - pos: 0.5,21.5
+      parent: 2
+      type: Transform
+  - uid: 368
+    components:
+    - pos: 1.5,21.5
+      parent: 2
+      type: Transform
+  - uid: 369
+    components:
+    - pos: 1.5,22.5
+      parent: 2
+      type: Transform
+  - uid: 370
+    components:
+    - pos: 1.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 371
+    components:
+    - pos: 1.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 372
+    components:
+    - pos: 0.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 373
+    components:
+    - pos: -0.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 374
+    components:
+    - pos: -0.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 375
+    components:
+    - pos: -0.5,22.5
+      parent: 2
+      type: Transform
+  - uid: 376
+    components:
+    - pos: -0.5,21.5
+      parent: 2
+      type: Transform
+  - uid: 377
+    components:
+    - pos: -0.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 378
+    components:
+    - pos: -1.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 379
+    components:
+    - pos: -2.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 380
+    components:
+    - pos: -2.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 381
+    components:
+    - pos: -2.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 382
+    components:
+    - pos: -2.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 383
+    components:
+    - pos: -3.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 384
+    components:
+    - pos: -4.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 385
+    components:
+    - pos: -5.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 386
+    components:
+    - pos: -6.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 387
+    components:
+    - pos: -7.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 388
+    components:
+    - pos: -8.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 389
+    components:
+    - pos: -8.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 390
+    components:
+    - pos: -9.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 391
+    components:
+    - pos: -10.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 392
+    components:
+    - pos: -11.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 393
+    components:
+    - pos: -11.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 394
+    components:
+    - pos: -10.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 395
+    components:
+    - pos: -9.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 396
+    components:
+    - pos: -8.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 397
+    components:
+    - pos: -2.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 398
+    components:
+    - pos: -2.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 399
+    components:
+    - pos: -2.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 400
+    components:
+    - pos: -1.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 401
+    components:
+    - pos: -0.5,9.5
+      parent: 2
+      type: Transform
+- proto: CableHV
+  entities:
+  - uid: 299
+    components:
+    - pos: -0.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 300
+    components:
+    - pos: 0.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 301
+    components:
+    - pos: 0.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 302
+    components:
+    - pos: 0.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 303
+    components:
+    - pos: -0.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 304
+    components:
+    - pos: -1.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 305
+    components:
+    - pos: -1.5,10.5
+      parent: 2
+      type: Transform
+- proto: CableMV
+  entities:
+  - uid: 307
+    components:
+    - pos: -1.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 308
+    components:
+    - pos: -1.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 309
+    components:
+    - pos: -0.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 310
+    components:
+    - pos: 0.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 311
+    components:
+    - pos: 1.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 312
+    components:
+    - pos: 2.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 313
+    components:
+    - pos: 2.5,10.5
+      parent: 2
+      type: Transform
+- proto: CargoPallet
+  entities:
+  - uid: 404
+    components:
+    - pos: 8.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 405
+    components:
+    - pos: 7.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 406
+    components:
+    - pos: 6.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 407
+    components:
+    - pos: 5.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 408
+    components:
+    - pos: 4.5,11.5
+      parent: 2
+      type: Transform
+- proto: chem_master
+  entities:
+  - uid: 185
+    components:
+    - pos: -0.5,7.5
+      parent: 2
+      type: Transform
+- proto: ChemDispenser
+  entities:
+  - uid: 184
+    components:
+    - pos: -0.5,8.5
+      parent: 2
+      type: Transform
+- proto: ComfyChair
+  entities:
+  - uid: 174
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,12.5
+      parent: 2
+      type: Transform
+- proto: ComputerSalvageExpedition
+  entities:
+  - uid: 168
+    components:
+    - pos: -0.5,13.5
+      parent: 2
+      type: Transform
+- proto: ComputerShuttle
+  entities:
+  - uid: 166
+    components:
+    - pos: 0.5,13.5
+      parent: 2
+      type: Transform
+- proto: ComputerStationRecords
+  entities:
+  - uid: 167
+    components:
+    - pos: 1.5,13.5
+      parent: 2
+      type: Transform
+- proto: CrateEmptySpawner
+  entities:
+  - uid: 447
+    components:
+    - pos: 8.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 448
+    components:
+    - pos: -0.5,20.5
+      parent: 2
+      type: Transform
+  - uid: 449
+    components:
+    - pos: -0.5,18.5
+      parent: 2
+      type: Transform
+  - uid: 450
+    components:
+    - pos: -0.5,17.5
+      parent: 2
+      type: Transform
+  - uid: 451
+    components:
+    - pos: -4.5,11.5
+      parent: 2
+      type: Transform
+- proto: CrateMaterialPlastic
+  entities:
+  - uid: 452
+    components:
+    - pos: 4.5,13.5
+      parent: 2
+      type: Transform
+- proto: DefibrillatorCabinet
+  entities:
+  - uid: 297
+    components:
+    - pos: -1.5,8.5
+      parent: 2
+      type: Transform
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 202
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,14.5
+      parent: 2
+      type: Transform
+- proto: FireAxeCabinetFilled
+  entities:
+  - uid: 423
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,14.5
+      parent: 2
+      type: Transform
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 173
+    components:
+    - pos: 1.5,11.5
+      parent: 2
+      type: Transform
+- proto: Grille
+  entities:
+  - uid: 190
+    components:
+    - pos: 2.5,-0.5
+      parent: 2
+      type: Transform
+  - uid: 191
+    components:
+    - pos: 2.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 192
+    components:
+    - pos: 3.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 193
+    components:
+    - pos: 3.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 194
+    components:
+    - pos: 2.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 195
+    components:
+    - pos: -1.5,-0.5
+      parent: 2
+      type: Transform
+  - uid: 196
+    components:
+    - pos: -1.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 197
+    components:
+    - pos: -1.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 198
+    components:
+    - pos: -2.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 199
+    components:
+    - pos: -2.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 200
+    components:
+    - pos: 2.5,2.5
+      parent: 2
+      type: Transform
+  - uid: 201
+    components:
+    - pos: 2.5,3.5
+      parent: 2
+      type: Transform
+  - uid: 203
+    components:
+    - pos: 2.5,5.5
+      parent: 2
+      type: Transform
+  - uid: 204
+    components:
+    - pos: 2.5,6.5
+      parent: 2
+      type: Transform
+  - uid: 205
+    components:
+    - pos: 2.5,7.5
+      parent: 2
+      type: Transform
+  - uid: 206
+    components:
+    - pos: -1.5,2.5
+      parent: 2
+      type: Transform
+  - uid: 207
+    components:
+    - pos: -1.5,3.5
+      parent: 2
+      type: Transform
+  - uid: 209
+    components:
+    - pos: -1.5,5.5
+      parent: 2
+      type: Transform
+  - uid: 210
+    components:
+    - pos: -1.5,6.5
+      parent: 2
+      type: Transform
+  - uid: 211
+    components:
+    - pos: -1.5,7.5
+      parent: 2
+      type: Transform
+  - uid: 212
+    components:
+    - pos: 3.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 213
+    components:
+    - pos: 4.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 214
+    components:
+    - pos: -2.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 215
+    components:
+    - pos: -3.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 216
+    components:
+    - pos: 5.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 217
+    components:
+    - pos: 6.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 218
+    components:
+    - pos: 7.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 220
+    components:
+    - pos: 9.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 221
+    components:
+    - pos: 10.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 222
+    components:
+    - pos: 11.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 223
+    components:
+    - pos: 11.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 224
+    components:
+    - pos: 12.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 225
+    components:
+    - pos: 12.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 226
+    components:
+    - pos: 13.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 227
+    components:
+    - pos: 13.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 228
+    components:
+    - pos: 12.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 229
+    components:
+    - pos: 12.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 230
+    components:
+    - pos: 11.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 231
+    components:
+    - pos: 11.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 232
+    components:
+    - pos: 10.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 233
+    components:
+    - pos: 9.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 235
+    components:
+    - pos: 7.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 236
+    components:
+    - pos: 6.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 237
+    components:
+    - pos: 5.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 238
+    components:
+    - pos: 4.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 239
+    components:
+    - pos: 3.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 240
+    components:
+    - pos: -4.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 241
+    components:
+    - pos: -5.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 242
+    components:
+    - pos: -6.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 244
+    components:
+    - pos: -8.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 245
+    components:
+    - pos: -9.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 246
+    components:
+    - pos: -10.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 247
+    components:
+    - pos: -10.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 248
+    components:
+    - pos: -11.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 249
+    components:
+    - pos: -11.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 250
+    components:
+    - pos: -12.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 251
+    components:
+    - pos: -4.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 252
+    components:
+    - pos: -5.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 253
+    components:
+    - pos: -6.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 255
+    components:
+    - pos: -8.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 256
+    components:
+    - pos: -9.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 257
+    components:
+    - pos: -10.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 258
+    components:
+    - pos: -10.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 259
+    components:
+    - pos: -11.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 260
+    components:
+    - pos: -11.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 261
+    components:
+    - pos: -12.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 262
+    components:
+    - pos: -3.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 263
+    components:
+    - pos: -2.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 264
+    components:
+    - pos: 2.5,17.5
+      parent: 2
+      type: Transform
+  - uid: 265
+    components:
+    - pos: 2.5,18.5
+      parent: 2
+      type: Transform
+  - uid: 266
+    components:
+    - pos: 2.5,19.5
+      parent: 2
+      type: Transform
+  - uid: 268
+    components:
+    - pos: 2.5,21.5
+      parent: 2
+      type: Transform
+  - uid: 269
+    components:
+    - pos: 2.5,22.5
+      parent: 2
+      type: Transform
+  - uid: 270
+    components:
+    - pos: 2.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 271
+    components:
+    - pos: 3.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 272
+    components:
+    - pos: 3.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 273
+    components:
+    - pos: 2.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 274
+    components:
+    - pos: 2.5,25.5
+      parent: 2
+      type: Transform
+  - uid: 275
+    components:
+    - pos: -1.5,17.5
+      parent: 2
+      type: Transform
+  - uid: 276
+    components:
+    - pos: -1.5,18.5
+      parent: 2
+      type: Transform
+  - uid: 277
+    components:
+    - pos: -1.5,19.5
+      parent: 2
+      type: Transform
+  - uid: 279
+    components:
+    - pos: -1.5,21.5
+      parent: 2
+      type: Transform
+  - uid: 280
+    components:
+    - pos: -1.5,22.5
+      parent: 2
+      type: Transform
+  - uid: 281
+    components:
+    - pos: -1.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 282
+    components:
+    - pos: -2.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 283
+    components:
+    - pos: -1.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 284
+    components:
+    - pos: -2.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 285
+    components:
+    - pos: -1.5,25.5
+      parent: 2
+      type: Transform
+  - uid: 286
+    components:
+    - pos: 2.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 287
+    components:
+    - pos: 2.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 288
+    components:
+    - pos: 2.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 289
+    components:
+    - pos: 1.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 290
+    components:
+    - pos: 0.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 291
+    components:
+    - pos: -0.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 292
+    components:
+    - pos: -1.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 293
+    components:
+    - pos: -1.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 294
+    components:
+    - pos: -1.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 295
+    components:
+    - pos: -0.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 296
+    components:
+    - pos: 1.5,10.5
+      parent: 2
+      type: Transform
+- proto: Gyroscope
+  entities:
+  - uid: 435
+    components:
+    - pos: 5.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 436
+    components:
+    - pos: -4.5,16.5
+      parent: 2
+      type: Transform
+- proto: LargeBeaker
+  entities:
+  - uid: 189
+    components:
+    - pos: -0.49219155,8.452471
+      parent: 2
+      type: Transform
+- proto: LockerChemistryFilled
+  entities:
+  - uid: 188
+    components:
+    - pos: -0.5,5.5
+      parent: 2
+      type: Transform
+- proto: LockerSalvageSpecialistFilled
+  entities:
+  - uid: 177
+    components:
+    - pos: 1.5,17.5
+      parent: 2
+      type: Transform
+  - uid: 178
+    components:
+    - pos: 1.5,18.5
+      parent: 2
+      type: Transform
+- proto: MedicalBed
+  entities:
+  - uid: 183
+    components:
+    - pos: -0.5,6.5
+      parent: 2
+      type: Transform
+- proto: OreProcessor
+  entities:
+  - uid: 175
+    components:
+    - pos: 5.5,13.5
+      parent: 2
+      type: Transform
+- proto: PortableGeneratorPacmanShuttle
+  entities:
+  - uid: 172
+    components:
+    - pos: -0.5,11.5
+      parent: 2
+      type: Transform
+    - on: False
+      type: FuelGenerator
+    - bodyType: Static
+      type: Physics
+- proto: Poweredlight
+  entities:
+  - uid: 7
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -11.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 13
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 12.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 14
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 20
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 2
+      type: Transform
+  - uid: 26
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,20.5
+      parent: 2
+      type: Transform
+  - uid: 208
+    components:
+    - pos: 0.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 234
+    components:
+    - pos: -7.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 402
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 424
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 425
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 426
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 427
+    components:
+    - pos: -3.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 428
+    components:
+    - pos: -1.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 429
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 2
+      type: Transform
+- proto: Rack
+  entities:
+  - uid: 430
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,15.5
+      parent: 2
+      type: Transform
+- proto: RandomVendingDrinks
+  entities:
+  - uid: 181
+    components:
+    - pos: -4.5,13.5
+      parent: 2
+      type: Transform
+- proto: RandomVendingSnacks
+  entities:
+  - uid: 182
+    components:
+    - pos: -5.5,13.5
+      parent: 2
+      type: Transform
+- proto: SheetPlasma
+  entities:
+  - uid: 422
+    components:
+    - pos: -0.58219266,11.407423
+      parent: 2
+      type: Transform
+- proto: ShuttleGunKinetic
+  entities:
+  - uid: 61
+    components:
+    - pos: -2.5,-0.5
+      parent: 2
+      type: Transform
+    - links:
+      - 417
+      type: DeviceLinkSink
+  - uid: 62
+    components:
+    - pos: 3.5,-0.5
+      parent: 2
+      type: Transform
+    - links:
+      - 417
+      type: DeviceLinkSink
+  - uid: 103
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -12.5,9.5
+      parent: 2
+      type: Transform
+    - links:
+      - 420
+      type: DeviceLinkSink
+  - uid: 104
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -12.5,15.5
+      parent: 2
+      type: Transform
+    - links:
+      - 420
+      type: DeviceLinkSink
+  - uid: 105
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,25.5
+      parent: 2
+      type: Transform
+    - links:
+      - 419
+      type: DeviceLinkSink
+  - uid: 106
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,25.5
+      parent: 2
+      type: Transform
+    - links:
+      - 419
+      type: DeviceLinkSink
+  - uid: 107
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 13.5,15.5
+      parent: 2
+      type: Transform
+    - links:
+      - 418
+      type: DeviceLinkSink
+  - uid: 108
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 13.5,9.5
+      parent: 2
+      type: Transform
+    - links:
+      - 418
+      type: DeviceLinkSink
+- proto: ShuttleWindow
+  entities:
+  - uid: 3
+    components:
+    - pos: 13.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 4
+    components:
+    - pos: 2.5,7.5
+      parent: 2
+      type: Transform
+  - uid: 5
+    components:
+    - pos: 2.5,6.5
+      parent: 2
+      type: Transform
+  - uid: 6
+    components:
+    - pos: 2.5,5.5
+      parent: 2
+      type: Transform
+  - uid: 8
+    components:
+    - pos: 2.5,3.5
+      parent: 2
+      type: Transform
+  - uid: 9
+    components:
+    - pos: 2.5,2.5
+      parent: 2
+      type: Transform
+  - uid: 10
+    components:
+    - pos: -1.5,7.5
+      parent: 2
+      type: Transform
+  - uid: 11
+    components:
+    - pos: -1.5,6.5
+      parent: 2
+      type: Transform
+  - uid: 12
+    components:
+    - pos: -1.5,5.5
+      parent: 2
+      type: Transform
+  - uid: 15
+    components:
+    - pos: -1.5,3.5
+      parent: 2
+      type: Transform
+  - uid: 16
+    components:
+    - pos: -1.5,2.5
+      parent: 2
+      type: Transform
+  - uid: 17
+    components:
+    - pos: 5.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 18
+    components:
+    - pos: 6.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 19
+    components:
+    - pos: 7.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 21
+    components:
+    - pos: 9.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 22
+    components:
+    - pos: 10.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 23
+    components:
+    - pos: 5.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 24
+    components:
+    - pos: 6.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 25
+    components:
+    - pos: 7.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 27
+    components:
+    - pos: 9.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 28
+    components:
+    - pos: 10.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 29
+    components:
+    - pos: 2.5,17.5
+      parent: 2
+      type: Transform
+  - uid: 30
+    components:
+    - pos: 2.5,18.5
+      parent: 2
+      type: Transform
+  - uid: 31
+    components:
+    - pos: 2.5,19.5
+      parent: 2
+      type: Transform
+  - uid: 33
+    components:
+    - pos: 2.5,21.5
+      parent: 2
+      type: Transform
+  - uid: 34
+    components:
+    - pos: 2.5,22.5
+      parent: 2
+      type: Transform
+  - uid: 35
+    components:
+    - pos: -1.5,17.5
+      parent: 2
+      type: Transform
+  - uid: 36
+    components:
+    - pos: -1.5,18.5
+      parent: 2
+      type: Transform
+  - uid: 37
+    components:
+    - pos: -1.5,19.5
+      parent: 2
+      type: Transform
+  - uid: 39
+    components:
+    - pos: -1.5,21.5
+      parent: 2
+      type: Transform
+  - uid: 40
+    components:
+    - pos: -1.5,22.5
+      parent: 2
+      type: Transform
+  - uid: 41
+    components:
+    - pos: -4.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 42
+    components:
+    - pos: -5.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 43
+    components:
+    - pos: -6.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 45
+    components:
+    - pos: -8.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 46
+    components:
+    - pos: -9.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 47
+    components:
+    - pos: -4.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 48
+    components:
+    - pos: -5.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 49
+    components:
+    - pos: -6.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 51
+    components:
+    - pos: -8.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 52
+    components:
+    - pos: -9.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 53
+    components:
+    - pos: -1.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 54
+    components:
+    - pos: -2.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 55
+    components:
+    - pos: -2.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 56
+    components:
+    - pos: 2.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 57
+    components:
+    - pos: 3.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 58
+    components:
+    - pos: 3.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 63
+    components:
+    - pos: -1.5,-0.5
+      parent: 2
+      type: Transform
+  - uid: 64
+    components:
+    - pos: -1.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 65
+    components:
+    - pos: 2.5,-0.5
+      parent: 2
+      type: Transform
+  - uid: 66
+    components:
+    - pos: 2.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 68
+    components:
+    - pos: 0.5,1.5
+      parent: 2
+      type: Transform
+  - uid: 73
+    components:
+    - pos: 12.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 74
+    components:
+    - pos: 11.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 75
+    components:
+    - pos: 11.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 76
+    components:
+    - pos: 12.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 77
+    components:
+    - pos: -10.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 78
+    components:
+    - pos: 11.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 79
+    components:
+    - pos: 11.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 80
+    components:
+    - pos: 12.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 81
+    components:
+    - pos: 12.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 82
+    components:
+    - pos: 13.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 83
+    components:
+    - pos: 2.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 84
+    components:
+    - pos: 2.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 85
+    components:
+    - pos: 2.5,25.5
+      parent: 2
+      type: Transform
+  - uid: 86
+    components:
+    - pos: 3.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 87
+    components:
+    - pos: 3.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 88
+    components:
+    - pos: -1.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 89
+    components:
+    - pos: -1.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 90
+    components:
+    - pos: -1.5,25.5
+      parent: 2
+      type: Transform
+  - uid: 91
+    components:
+    - pos: -2.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 92
+    components:
+    - pos: -2.5,24.5
+      parent: 2
+      type: Transform
+  - uid: 93
+    components:
+    - pos: -10.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 94
+    components:
+    - pos: -11.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 95
+    components:
+    - pos: -12.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 96
+    components:
+    - pos: -10.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 97
+    components:
+    - pos: -11.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 98
+    components:
+    - pos: -11.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 99
+    components:
+    - pos: -12.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 100
+    components:
+    - pos: -10.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 101
+    components:
+    - pos: -11.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 122
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -10.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 124
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,23.5
+      parent: 2
+      type: Transform
+  - uid: 126
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 11.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 135
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 136
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 137
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 138
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 139
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 140
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 141
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 142
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 151
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 153
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 155
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 156
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 157
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 159
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 160
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 161
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 163
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 164
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 165
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,13.5
+      parent: 2
+      type: Transform
+- proto: SignalButton
+  entities:
+  - uid: 417
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 2
+      type: Transform
+    - linkedPorts:
+        62:
+        - Pressed: Toggle
+        - Pressed: Trigger
+        61:
+        - Pressed: Toggle
+        - Pressed: Trigger
+      type: DeviceLinkSource
+  - uid: 418
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 2
+      type: Transform
+    - linkedPorts:
+        107:
+        - Pressed: Toggle
+        - Pressed: Trigger
+        108:
+        - Pressed: Toggle
+        - Pressed: Trigger
+      type: DeviceLinkSource
+  - uid: 419
+    components:
+    - pos: 0.5,22.5
+      parent: 2
+      type: Transform
+    - linkedPorts:
+        105:
+        - Pressed: Toggle
+        - Pressed: Trigger
+        106:
+        - Pressed: Toggle
+        - Pressed: Trigger
+      type: DeviceLinkSource
+  - uid: 420
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,12.5
+      parent: 2
+      type: Transform
+    - linkedPorts:
+        103:
+        - Pressed: Toggle
+        - Pressed: Trigger
+        104:
+        - Pressed: Toggle
+        - Pressed: Trigger
+      type: DeviceLinkSource
+- proto: SmallThruster
+  entities:
+  - uid: 219
+    components:
+    - pos: 4.5,17.5
+      parent: 2
+      type: Transform
+  - uid: 437
+    components:
+    - pos: -3.5,17.5
+      parent: 2
+      type: Transform
+  - uid: 438
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 439
+    components:
+    - pos: 8.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 440
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 2
+      type: Transform
+  - uid: 441
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 8.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 442
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,7.5
+      parent: 2
+      type: Transform
+  - uid: 443
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 444
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -7.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 445
+    components:
+    - pos: -7.5,15.5
+      parent: 2
+      type: Transform
+- proto: SpawnPointChemist
+  entities:
+  - uid: 421
+    components:
+    - pos: 0.5,5.5
+      parent: 2
+      type: Transform
+- proto: SpawnPointSalvageSpecialist
+  entities:
+  - uid: 179
+    components:
+    - pos: 0.5,18.5
+      parent: 2
+      type: Transform
+  - uid: 180
+    components:
+    - pos: 0.5,17.5
+      parent: 2
+      type: Transform
+- proto: SubstationWallBasic
+  entities:
+  - uid: 298
+    components:
+    - pos: -1.5,10.5
+      parent: 2
+      type: Transform
+- proto: Table
+  entities:
+  - uid: 71
+    components:
+    - pos: 0.5,2.5
+      parent: 2
+      type: Transform
+  - uid: 147
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -9.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 148
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,22.5
+      parent: 2
+      type: Transform
+  - uid: 149
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 10.5,12.5
+      parent: 2
+      type: Transform
+- proto: VendingMachineSalvage
+  entities:
+  - uid: 176
+    components:
+    - pos: 6.5,13.5
+      parent: 2
+      type: Transform
+- proto: VendingMachineWallMedical
+  entities:
+  - uid: 186
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 2
+      type: Transform
+- proto: WallShuttle
+  entities:
+  - uid: 32
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 2
+      type: Transform
+  - uid: 38
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 44
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,20.5
+      parent: 2
+      type: Transform
+  - uid: 50
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 67
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 2
+      type: Transform
+  - uid: 121
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -12.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 123
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,25.5
+      parent: 2
+      type: Transform
+  - uid: 125
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 13.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 127
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 128
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 129
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 130
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 131
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 132
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 133
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 134
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 143
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 144
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 145
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 146
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,16.5
+      parent: 2
+      type: Transform
+  - uid: 150
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 154
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 158
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 162
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 243
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 254
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,20.5
+      parent: 2
+      type: Transform
+  - uid: 267
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 2
+      type: Transform
+  - uid: 278
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,14.5
+      parent: 2
+      type: Transform
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 434
+    components:
+    - pos: -1.5,16.5
+      parent: 2
+      type: Transform
+- proto: WarpPointShip
+  entities:
+  - uid: 72
+    components:
+    - pos: 0.5,12.5
+      parent: 2
+      type: Transform
+- proto: WeaponLaserGun
+  entities:
+  - uid: 431
+    components:
+    - pos: 0.4668212,15.794926
+      parent: 2
+      type: Transform
+  - uid: 432
+    components:
+    - pos: 0.4824462,15.623051
+      parent: 2
+      type: Transform
+  - uid: 433
+    components:
+    - pos: 0.4824462,15.388676
+      parent: 2
+      type: Transform
+- proto: WindoorSecure
+  entities:
+  - uid: 171
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,11.5
+      parent: 2
+      type: Transform
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 169
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 170
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,11.5
+      parent: 2
+      type: Transform
+...

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -349,7 +349,7 @@
           acts: ["Destruction"]
   - type: Gun
     projectileSpeed: 20
-    fireRate: 2
+    fireRate: 1
     selectedMode: SemiAuto
     angleDecay: 45
     minAngle: 5
@@ -361,7 +361,7 @@
       params:
         variation: 0.12
   - type: RechargeBasicEntityAmmo
-    rechargeCooldown: 2
+    rechargeCooldown: 1
     rechargeSound:
       path: /Audio/Weapons/Guns/Bolt/lmg_bolt_closed.ogg
       params:

--- a/Resources/Prototypes/_PAX/Sectors/alpha.yml
+++ b/Resources/Prototypes/_PAX/Sectors/alpha.yml
@@ -32,7 +32,7 @@
        b: 3
      path: /Maps/_NF/POI/caseyscasino.yml
    - type: sectorOutpost
-     id: 4
+     id: 3
      location:
        distance: 2000
      color:
@@ -41,7 +41,7 @@
        b: 3
      path: /Maps/_NF/POI/courthouse.yml
    - type: sectorOutpost
-     id: 6
+     id: 4
      location:
        distance: 1000
      color:
@@ -50,7 +50,7 @@
        b: 3
      path: Maps/_NF/POI/beacon.yml
    - type: sectorOutpost
-     id: 7
+     id: 5
      location:
        distance: 3000
      color:
@@ -59,7 +59,7 @@
        b: 3
      path: Maps/_PAX/POI/gregend.yml
    - type: sectorOutpost
-     id: 8
+     id: 6
      location:
        distance: 2500
      color:

--- a/Resources/Prototypes/_PAX/Sectors/beta.yml
+++ b/Resources/Prototypes/_PAX/Sectors/beta.yml
@@ -3,7 +3,7 @@
   name: Beta
   station:
     type: sectorStation
-    id: 1
+    id: 7
     location:
       distance: 0
     color:
@@ -14,7 +14,7 @@
     stationName: FTL Beacon
   outposts:
   - type: sectorOutpost
-    id: 1
+    id: 8
     location:
       position:
         x: 4500
@@ -25,7 +25,7 @@
       b: 3
     path: /Maps/_NF/POI/cargodepot.yml
   - type: sectorOutpost
-    id: 2
+    id: 9
     location:
       position:
         x: -4500
@@ -36,7 +36,7 @@
       b: 3
     path: /Maps/_NF/POI/cargodepot.yml
   - type: sectorOutpost
-    id: 3
+    id: 10
     location:
       distance: 3500
     color:
@@ -45,7 +45,7 @@
       b: 3
     path: /Maps/_NF/POI/lpbravo.yml
   - type: sectorOutpost
-    id: 4
+    id: 11
     location:
       distance: 2500
     color:
@@ -63,7 +63,7 @@
       b: 3
     path: /Maps/_NF/POI/cove.yml
   - type: sectorOutpost
-    id: 5
+    id: 12
     location:
       distance: 1500
     color:
@@ -72,7 +72,7 @@
       b: 3
     path: /Maps/_NF/POI/anomalouslab.yml
   - type: sectorOutpost
-    id: 9
+    id: 13
     location:
       distance: 2500
     color:
@@ -81,7 +81,7 @@
       b: 3
     path: /Maps/_PAX/POI/invictus.yml
   - type: sectorOutpost
-    id: 10
+    id: 14
     location:
       distance: 2500
     color:

--- a/Resources/Prototypes/_PAX/Shipyard/shuriken.yml
+++ b/Resources/Prototypes/_PAX/Shipyard/shuriken.yml
@@ -1,0 +1,38 @@
+# Author Info
+# GitHub: https://github.com/gry-man
+# Discord: https://discord.gg/txmQT9Ym
+
+# Maintainer Info
+# GitHub: https://github.com/gry-man
+# Discord: https://discord.gg/txmQT9Ym
+
+# Shuttle Notes:
+
+- type: vessel
+  id: Shuriken
+  name: NC Shuriken
+  description: Shuriken-shaped expedition and mining vessel designed for shock operations on planets. Comes with dematerializers on all 4 directions and super compact sick-bay with chemistry.
+  price: 103000
+  category: Small
+  group: Expedition
+  shuttlePath: /Maps/_PAX/Shuttles/shuriken.yml
+
+- type: gameMap
+  id: Shuriken
+  mapName: 'NC Shuriken'
+  mapPath: /Maps/_PAX/Shuttles/shuriken.yml
+  minPlayers: 0
+  stations:
+    Shuriken:
+      stationProto: StandardFrontierExpeditionVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'NC Shuriken {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          overflowJobs: []
+          availableJobs:
+            Chemist: [ 0, 0 ]
+            SalvageSpecialist: [ 0, 0 ]


### PR DESCRIPTION
NC Shuriken - shock salvage operation vessel added. to expedition shipyard. Matter Dematerializer shuttle gun is now 50% times faster, and recharges in half the previous time. Default money characters start with increased from 25k to 30k.
